### PR TITLE
fix: Default parameter as environment variables

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pywarp10"
-version = "0.1.1"
+version = "0.1.2"
 description = "Simplify use of warpscript with python."
 authors = ["Denis Roussel <droussel@centreon.com>"]
 

--- a/pywarp10.py
+++ b/pywarp10.py
@@ -80,12 +80,12 @@ class Warpscript:
 
     def __init__(
         self,
-        host: str = os.getenv("WARP10_HOST", "127.0.0.1"),
-        port: int = int(os.getenv("WARP10_PORT", 25333)),
+        host: Optional[str] = None,
+        port: Optional[int] = None,
     ) -> None:
         """Inits Warpscript with default host and port"""
-        self.host = host
-        self.port = port
+        self.host = host if host is not None else os.getenv("WARP10_HOST", "127.0.0.1")
+        self.port = port if port is not None else int(os.getenv("WARP10_PORT", 25333))
         self.warpscript = ""
 
     def __repr__(self):

--- a/test_pywarp10.py
+++ b/test_pywarp10.py
@@ -14,7 +14,7 @@ def test_sanitize():
         "dict": {},
         "date": "2020-01-01",
     }
-    result = "{\n 'string' 'foo'\n 'numeric' 1\n 'boolean' TRUE\n 'list' []\n 'dict' {}\n 'date' 2020-01-01T00:00:00.000000Z\n}"
+    result = "{\n 'string' 'foo'\n 'numeric' 1\n 'boolean' TRUE\n 'list' []\n 'dict' {}\n 'date' '2020-01-01T00:00:00.000000Z'\n}"
     assert ws.sanitize(object) == result
 
     # Test error


### PR DESCRIPTION
Default parameters are evaluated when the function is defined and not when the function is called.
Therefore, default parameter define by an environment variable should be created inside the function.

See here for a similar issue: https://stackoverflow.com/questions/60529568/os-getenv-doesnt-work-as-default-value-for-a-function-parameter-if-set-within-p