### PR TITLE
fix: restrict date sanitizer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pywarp10"
-version = "0.1.2"
+version = "0.1.3"
 description = "Simplify use of warpscript with python."
 authors = ["Denis Roussel <droussel@centreon.com>"]
 

--- a/pywarp10.py
+++ b/pywarp10.py
@@ -295,7 +295,9 @@ class Warpscript:
                 duration = 0
             if duration > 0:
                 return duration
-            date = dateparser.parse(x)
+            date = dateparser.parse(
+                x, settings={"REQUIRE_PARTS": ["day", "month", "year"]}
+            )
             if date is not None:
                 date = date.replace(tzinfo=None)
                 x = date.isoformat(timespec="microseconds") + "Z"

--- a/test_pywarp10.py
+++ b/test_pywarp10.py
@@ -13,8 +13,9 @@ def test_sanitize():
         "list": [],
         "dict": {},
         "date": "2020-01-01",
+        "string_number": "1871",
     }
-    result = "{\n 'string' 'foo'\n 'numeric' 1\n 'boolean' TRUE\n 'list' []\n 'dict' {}\n 'date' '2020-01-01T00:00:00.000000Z'\n}"
+    result = "{\n 'string' 'foo'\n 'numeric' 1\n 'boolean' TRUE\n 'list' []\n 'dict' {}\n 'date' '2020-01-01T00:00:00.000000Z'\n 'string_number' '1871'\n}"
     assert ws.sanitize(object) == result
 
     # Test error


### PR DESCRIPTION
`dateparser.parse` is very laxed concerning input entry.
For example `sanitize("1871")` would return a date.
This PR enforce a string to have at least the year,  the month and a date before being converted to a date object.